### PR TITLE
♻️ Refactor go-instaman's command and package `internal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ See, for instance:
 * The list of [pull requests](https://github.com/luca-arch/instaman/pulls?q=is%3Apr)
 * The [commit history](https://github.com/luca-arch/instaman/commits)
 
+Note all commits messages are prepended with [gitmoji](https://gitmoji.dev).
+
 ## Set up
 
 ### Dependencies

--- a/go-instaman/Dockerfile
+++ b/go-instaman/Dockerfile
@@ -19,6 +19,7 @@ RUN go build -o api-server ./cmd/api-server/main.go
 FROM alpine:3.20.2
 
 ENV GOMAXPROCS="1"
+ENV ISDOCKER="1"
 COPY --from=builder /mnt/src/api-server /srv/api-server
 
 EXPOSE 10000

--- a/go-instaman/cmd/api-server/main.go
+++ b/go-instaman/cmd/api-server/main.go
@@ -23,60 +23,24 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
-	"time"
 
-	"github.com/luca-arch/instaman/database"
-	"github.com/luca-arch/instaman/instaproxy"
+	"github.com/luca-arch/instaman/internal"
 	"github.com/luca-arch/instaman/service"
 	"github.com/luca-arch/instaman/webserver"
 )
 
-const (
-	instaproxyTimeout = 90 // The instaproxy client's timeout. High value to account for latency due to retries and login attempts.
-	psqlMaxPoolSize   = 5  // Postgres pool size (max)
-	psqlMinPoolSize   = 2  // Postgres pool size (min)
-)
-
 // Boot sets up the api webserver and its dependencies.
 func Boot(ctx context.Context, devMode bool) (*http.Server, *slog.Logger) {
-	// Set up logger.
-	var logger *slog.Logger
-
-	lvl := new(slog.LevelVar)
-	opts := &slog.HandlerOptions{
-		AddSource:   false,
-		Level:       lvl,
-		ReplaceAttr: nil,
-	}
-
-	if devMode {
-		opts.AddSource = true
-		logger = slog.New(slog.NewTextHandler(os.Stdout, opts))
-
-		lvl.Set(slog.LevelDebug)
-	} else {
-		logger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
-	}
+	isDocker := os.Getenv("ISDOCKER") == "1"
+	logger := internal.Logger(devMode)
 
 	// Set up dependencies.
-	db := database.NewPool(ctx, psqlDSN(devMode)).WithLogger(logger)
+	db := internal.Database(ctx, logger, isDocker)
+	igService := service.NewInstagramService(internal.Instaproxy(logger, isDocker))
 	jobService := service.NewJobsService(db)
-	httpClient := &http.Client{Timeout: instaproxyTimeout * time.Second} //nolint:exhaustruct // Defaults are ok
-
-	// Set up Instaproxy client and service.
-	igClient := instaproxy.NewClient(httpClient, logger)
-	if devMode {
-		if err := igClient.BaseURL("http://127.0.0.1:15000"); err != nil {
-			panic(err)
-		}
-	}
-
-	igService := service.NewInstagramService(igClient)
 
 	// Init server with routes.
 	server, err := webserver.Create(ctx, jobService, igService, logger)
@@ -88,26 +52,8 @@ func Boot(ctx context.Context, devMode bool) (*http.Server, *slog.Logger) {
 	return server, logger
 }
 
-// psqlDSN builds the PostgreSQL DSN from the environment variables.
-func psqlDSN(devMode bool) string {
-	user, pass, db, host := os.Getenv("POSTGRES_DB"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_DB"), "postgres"
-
-	if devMode {
-		return "postgres://postgresuser:postgressecret@127.0.0.1:5432/database001?pool_max_conns=5&pool_min_conns=1"
-	}
-
-	return fmt.Sprintf("postgres://%s:%s@%s/%s?pool_max_conns=%d&pool_min_conns=%d",
-		user,
-		pass,
-		net.JoinHostPort(host, "5432"),
-		db,
-		psqlMaxPoolSize,
-		psqlMinPoolSize,
-	)
-}
-
 func main() {
-	devMode := flag.Bool("dev", false, "run in development mode (debug logger, and local instaproxy)")
+	devMode := flag.Bool("dev", false, "enable debug logger")
 	flag.Parse()
 
 	server, logger := Boot(context.Background(), *devMode)

--- a/go-instaman/cmd/api-server/main_test.go
+++ b/go-instaman/cmd/api-server/main_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// This test does almost nothing but increase code coverage.
 func TestBoot(t *testing.T) {
 	t.Parallel()
 

--- a/go-instaman/internal/cmd.go
+++ b/go-instaman/internal/cmd.go
@@ -1,0 +1,99 @@
+/*
+ * Instaman - Simple Instagram account manager.
+ *
+ * Copyright (C) 2024 Luca Contini
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package internal provides utilities that are only intended to be used by the go-instaman app itself.
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/luca-arch/instaman/database"
+	"github.com/luca-arch/instaman/instaproxy"
+)
+
+const (
+	instaproxyTimeout = 90 // The instaproxy client's timeout. High value to account for latency due to retries and login attempts.
+	psqlMaxPoolSize   = 5  // Postgres pool size (max)
+	psqlMinPoolSize   = 2  // Postgres pool size (min)
+)
+
+// Database builds a DSN to create and return a new database connection.
+func Database(ctx context.Context, logger *slog.Logger, isDocker bool) *database.Database {
+	var dsn string
+
+	if isDocker {
+		// Build DSN reading values from the environment.
+		user, pass, db, host := os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_DB"), "postgres"
+
+		dsn = fmt.Sprintf("postgres://%s:%s@%s/%s?pool_max_conns=%d&pool_min_conns=%d",
+			user,
+			pass,
+			net.JoinHostPort(host, "5432"),
+			db,
+			psqlMaxPoolSize,
+			psqlMinPoolSize,
+		)
+	} else {
+		// Hardcoded DSN string, with values from the original docker-compose.yml file
+		dsn = "postgres://postgresuser:postgressecret@127.0.0.1:5432/database001?pool_max_conns=5&pool_min_conns=1"
+	}
+
+	return database.
+		NewPool(ctx, dsn).
+		WithLogger(logger)
+}
+
+// Logger sets up a new slog.Logger and returns it.
+func Logger(debug bool) *slog.Logger {
+	lvl := new(slog.LevelVar)
+	opts := &slog.HandlerOptions{
+		AddSource:   debug,
+		Level:       lvl,
+		ReplaceAttr: nil,
+	}
+
+	if !debug {
+		return slog.New(slog.NewJSONHandler(os.Stdout, opts))
+	}
+
+	lvl.Set(slog.LevelDebug)
+
+	return slog.New(slog.NewTextHandler(os.Stdout, opts))
+}
+
+// Instaproxy sets up a new instaproxy client and returns it.
+func Instaproxy(logger *slog.Logger, isDocker bool) *instaproxy.Client {
+	httpClient := &http.Client{Timeout: instaproxyTimeout * time.Second} //nolint:exhaustruct // Defaults are ok
+
+	// Set up Instaproxy client and service.
+	igClient := instaproxy.NewClient(httpClient, logger)
+	if !isDocker {
+		if err := igClient.BaseURL("http://127.0.0.1:15000"); err != nil {
+			panic(err)
+		}
+	}
+
+	return igClient
+}

--- a/go-instaman/internal/cmd_test.go
+++ b/go-instaman/internal/cmd_test.go
@@ -1,0 +1,74 @@
+/*
+ * Instaman - Simple Instagram account manager.
+ *
+ * Copyright (C) 2024 Luca Contini
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// The main package for the api-server executable.
+package internal_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/luca-arch/instaman/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test does almost nothing but increase code coverage.
+func TestDatabase(t *testing.T) {
+	t.Parallel()
+
+	out := internal.Database(context.TODO(), nopLogger(t), true)
+	assert.NotNil(t, out)
+
+	out = internal.Database(context.TODO(), nopLogger(t), false)
+	assert.NotNil(t, out)
+}
+
+// This test does almost nothing but increase code coverage.
+func TestLogger(t *testing.T) {
+	t.Parallel()
+
+	out := internal.Logger(true)
+	assert.NotNil(t, out)
+	assert.True(t, out.Handler().Enabled(context.TODO(), slog.LevelDebug))
+
+	out = internal.Logger(false)
+	assert.NotNil(t, out)
+	assert.False(t, out.Handler().Enabled(context.TODO(), slog.LevelDebug))
+}
+
+// This test does almost nothing but increase code coverage.
+func TestInstaproxy(t *testing.T) {
+	t.Parallel()
+
+	out := internal.Instaproxy(nopLogger(t), true)
+	assert.NotNil(t, out)
+
+	out = internal.Instaproxy(nopLogger(t), false)
+	assert.NotNil(t, out)
+}
+
+func nopLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+
+	discard := slog.NewJSONHandler(io.Discard, nil)
+
+	return slog.New(discard)
+}

--- a/go-instaman/internal/httpin.go
+++ b/go-instaman/internal/httpin.go
@@ -17,7 +17,6 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Package internal.
 package internal
 
 import (


### PR DESCRIPTION
# Description

This refactor moves most logic from `cmd/api-server/main.go` into `internal/cmd.go` for later re-use with the worker command.

# Changeset

* Move mains' logic into internal package
* Introduce `ISDOCKER` env variable so the program knows when it's run inside a container (this changes the database and instaproxy hostnames in their respective DSNs)
* Update the main README file