### PR TITLE
✨ Update go-instaman package database

### DIFF
--- a/go-instaman/database/database.go
+++ b/go-instaman/database/database.go
@@ -139,7 +139,7 @@ func SelectOne[T any](ctx context.Context, db *Database, sql string, args ...any
 
 	defer res.Close()
 
-	out, err := pgx.CollectExactlyOneRow(res, pgx.RowToStructByPos[T])
+	out, err := pgx.CollectExactlyOneRow(res, pgx.RowToStructByNameLax[T])
 	if err != nil {
 		return nil, errors.Join(ErrDatabaseFailure, err)
 	}

--- a/go-instaman/database/database.go
+++ b/go-instaman/database/database.go
@@ -100,6 +100,20 @@ func Count(ctx context.Context, db *Database, sql string, args ...any) (int32, e
 	return count, nil
 }
 
+// Execute executes the provided SQL string without expecting anything to return.
+func Execute(ctx context.Context, db *Database, sql string, args ...any) error {
+	db.logger.Debug("Query", "sql", sql, "args", args)
+
+	res, err := db.cnx.Query(ctx, sql, args...)
+	if err != nil {
+		return errors.Join(ErrDatabaseFailure, err)
+	}
+
+	res.Close()
+
+	return nil
+}
+
 // Select executes the provided SQL and returns the whole resultset.
 func Select[T any](ctx context.Context, db *Database, sql string, args ...any) ([]T, error) {
 	db.logger.Debug("Query", "sql", sql, "args", args)

--- a/go-instaman/database/models/values.go
+++ b/go-instaman/database/models/values.go
@@ -20,9 +20,35 @@
 package models
 
 const (
+	JobFrequencyDaily    = "daily"
+	JobFrequencyWeekly   = "weekly"
+	JobStateActive       = "active"
+	JobStateError        = "error"
+	JobStateNew          = "new"
+	JobStatePaused       = "pause"
 	JobTypeCopyFollowers = "copy-followers"
 	JobTypeCopyFollowing = "copy-following"
 )
+
+// IsValidJobFrequency return whether job frequency is a valid value for the jobs.metadata ->> frequency column.
+func IsValidJobFrequency(jobFreq string) bool {
+	switch jobFreq {
+	case JobFrequencyDaily, JobFrequencyWeekly:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidJobState return whether state is a valid value for the jobs.state column.
+func IsValidJobState(jobType string) bool {
+	switch jobType {
+	case JobStateActive, JobStateError, JobStateNew, JobStatePaused:
+		return true
+	default:
+		return false
+	}
+}
 
 // IsValidJobType return whether jobType is a valid value for the jobs.job_type column.
 func IsValidJobType(jobType string) bool {

--- a/go-instaman/service/jobs.go
+++ b/go-instaman/service/jobs.go
@@ -56,7 +56,7 @@ func NewJobsService(db dbjobs) *Jobs {
 func (j *Jobs) FindCopyJob(ctx context.Context, params database.FindCopyJobParams) (*models.CopyJob, error) {
 	cj, err := j.db.FindCopyJob(ctx, params)
 	if err != nil {
-		return nil, errors.Join(err, ErrDBFailure)
+		return nil, errors.Join(ErrDBFailure, err)
 	}
 
 	return cj, nil
@@ -67,7 +67,7 @@ func (j *Jobs) FindCopyJob(ctx context.Context, params database.FindCopyJobParam
 func (j *Jobs) FindJob(ctx context.Context, params database.FindJobParams) (*models.Job, error) {
 	jj, err := j.db.FindJob(ctx, params)
 	if err != nil {
-		return nil, errors.Join(err, ErrDBFailure)
+		return nil, errors.Join(ErrDBFailure, err)
 	}
 
 	return jj, nil
@@ -77,7 +77,7 @@ func (j *Jobs) FindJob(ctx context.Context, params database.FindJobParams) (*mod
 func (j *Jobs) FindJobs(ctx context.Context, params database.FindJobsParams) ([]models.Job, error) {
 	jobs, err := j.db.FindJobs(ctx, params)
 	if err != nil {
-		return nil, errors.Join(err, ErrDBFailure)
+		return nil, errors.Join(ErrDBFailure, err)
 	}
 
 	return jobs, nil
@@ -87,7 +87,7 @@ func (j *Jobs) FindJobs(ctx context.Context, params database.FindJobsParams) ([]
 func (j *Jobs) NewCopyJob(ctx context.Context, params database.NewCopyJobParams) (*models.CopyJob, error) {
 	cj, err := j.db.NewCopyJob(ctx, params)
 	if err != nil {
-		return nil, errors.Join(err, ErrDBFailure)
+		return nil, errors.Join(ErrDBFailure, err)
 	}
 
 	return cj, nil


### PR DESCRIPTION
# Description

The database and related packages have been updated. There are now more strict validations around models and their values, with new constants to avoid mistakes and duplicate strings.

The `Job.Metadata` field of type `map[string]any` has been replaced by `BinData []byte` so the job's metadata is parsed by a new function (see `database/models.NewCopyJob`) to work around an issue with JSON and pgx encoding of some **int64** values that were incorrectly cast to **float64**.
This issue brought problems with many CopyJob's `Metadata.userID`, it is now solved.

# Changeset

* ✨ add `Execute` function and `UpdateJob` method in package database, these will be used later on by the UI and the worker
* ♻️ refactor package database with stricter validations and types
* ♻️ refactor wrapped errors to have a more natural order when joined