### PR TITLE
✨ Add  go-instaman worker application files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,3 +64,15 @@ services:
     mem_limit: "32M"
     ports:
       - "8080:8080"
+
+  worker:
+    <<: *unprivileged
+    build: ./go-instaman
+    cpus: 0.5
+    depends_on:
+      - instaproxy
+      - postgres
+    entrypoint: ["/srv/worker"]
+    environment:
+      <<: *db-credentials
+    mem_limit: "32M"

--- a/go-instaman/Dockerfile
+++ b/go-instaman/Dockerfile
@@ -13,6 +13,7 @@ COPY internal internal/
 COPY service service/
 COPY webserver webserver/
 RUN go build -o api-server ./cmd/api-server/main.go
+RUN go build -o worker ./cmd/worker/main.go
 
 
 # Golang app runner
@@ -21,6 +22,7 @@ FROM alpine:3.20.2
 ENV GOMAXPROCS="1"
 ENV ISDOCKER="1"
 COPY --from=builder /mnt/src/api-server /srv/api-server
+COPY --from=builder /mnt/src/worker /srv/worker
 
 EXPOSE 10000
 

--- a/go-instaman/cmd/worker/main.go
+++ b/go-instaman/cmd/worker/main.go
@@ -1,0 +1,59 @@
+/*
+ * Instaman - Simple Instagram account manager.
+ *
+ * Copyright (C) 2024 Luca Contini
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// The main package for the worker executable.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+
+	"github.com/luca-arch/instaman/internal"
+	"github.com/luca-arch/instaman/service"
+)
+
+// Boot sets up the worker and its dependencies.
+func Boot(ctx context.Context, devMode bool) (*service.Worker, *slog.Logger) {
+	isDocker := os.Getenv("ISDOCKER") == "1"
+	logger := internal.Logger(devMode)
+
+	// Set up dependencies.
+	db := internal.Database(ctx, logger, isDocker)
+	instaproxy := internal.Instaproxy(logger, isDocker)
+
+	// Init worker.
+	worker := service.NewWorkerService(db, logger, instaproxy)
+
+	return worker, logger
+}
+
+func main() {
+	devMode := flag.Bool("dev", false, "enable debug logger")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	worker, logger := Boot(ctx, *devMode)
+
+	logger.Info("starting worker...")
+
+	worker.StartCopying(ctx)
+}

--- a/go-instaman/cmd/worker/main_test.go
+++ b/go-instaman/cmd/worker/main_test.go
@@ -24,7 +24,7 @@ import (
 	"log/slog"
 	"testing"
 
-	apiserver "github.com/luca-arch/instaman/cmd/api-server"
+	worker "github.com/luca-arch/instaman/cmd/worker"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,9 +34,9 @@ func TestBoot(t *testing.T) {
 
 	ctx := context.TODO()
 
-	_, logger := apiserver.Boot(ctx, false)
+	_, logger := worker.Boot(ctx, false)
 	assert.False(t, logger.Handler().Enabled(ctx, slog.LevelDebug))
 
-	_, logger = apiserver.Boot(ctx, true)
+	_, logger = worker.Boot(ctx, true)
 	assert.True(t, logger.Handler().Enabled(ctx, slog.LevelDebug))
 }

--- a/go-instaman/database/worker.go
+++ b/go-instaman/database/worker.go
@@ -1,0 +1,162 @@
+/*
+ * Instaman - Simple Instagram account manager.
+ *
+ * Copyright (C) 2024 Luca Contini
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/luca-arch/instaman/database/models"
+	"github.com/luca-arch/instaman/instaproxy"
+)
+
+// InsertJobEvent registers a new event in the jobs' audit logs table.
+func (d *Database) InsertJobEvent(ctx context.Context, jobID int64, event string) error {
+	sqlEvent := `INSERT INTO jobs_events (event_msg, job_id, ts) VALUES ($1, $2, NOW())`
+
+	if err := Execute(ctx, d, sqlEvent, event, jobID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NextJob returns the first job that is ready for execution.
+func (d *Database) NextJob(ctx context.Context, jobType string) (*models.Job, error) {
+	sql := `
+	SELECT
+		id,
+		checksum,
+		job_type,
+		label,
+		last_run,
+		metadata,
+		next_run,
+		state
+	FROM
+		jobs
+	WHERE
+		job_type = $1
+		AND next_run IS NOT NULL
+		AND next_run < NOW()
+		AND state IN ($2, $3)
+	ORDER BY
+		next_run ASC
+	LIMIT 1
+	`
+
+	job, err := SelectOne[models.Job](ctx, d, sql, jobType, models.JobStateActive, models.JobStateNew)
+
+	switch {
+	case err == nil:
+		return job, nil
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil //nolint:nilnil // It means not found.
+	default:
+		return nil, err
+	}
+}
+
+// ScheduleJob updates a job's `next_run` column.
+func (d *Database) ScheduleJob(ctx context.Context, jobID int64, nextRun time.Duration) error {
+	interval := fmt.Sprintf("%d SECOND", int(nextRun.Seconds()))
+	sqlUpdate := `
+		UPDATE jobs
+			SET next_run = NOW() + INTERVAL '` + interval + `',
+			state = $1
+		WHERE id = $2
+	`
+
+	if err := Execute(ctx, d, sqlUpdate, models.JobStateActive, jobID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StoreCopyJobResults updates the `user_followers` or `user_following` tables and the `jobs.metadata.cursor` value.
+func (d *Database) StoreCopyJobResults(ctx context.Context, job *models.CopyJob, results *instaproxy.Connections) error {
+	table := "user_followers"
+	if job.Type == models.JobTypeCopyFollowing {
+		table = "user_following"
+	}
+
+	sql := fmt.Sprintf(`
+		INSERT INTO %s (account_id, first_seen, handler, last_seen, pic_url, user_id)
+			VALUES ($1, NOW(), $2, NOW(), $3, $4)
+		ON CONFLICT (account_id, user_id) DO UPDATE
+			SET last_seen = NOW(), handler = $2, pic_url = $3
+	`, table)
+
+	for _, u := range results.Users {
+		d.logger.Debug("upsert "+table, "job.id", job.ID, "user", u)
+
+		if err := Execute(ctx, d, sql, job.Metadata.UserID, u.Handler, urlStringPtr(u.PictureURL), u.ID); err != nil {
+			return err
+		}
+	}
+
+	if results.Next == nil {
+		sql = `
+			UPDATE jobs SET
+				metadata = jsonb_set(metadata, '{cursor}', 'null'::jsonb),
+				state = $1
+			WHERE id = $2
+		`
+
+		return Execute(ctx, d, sql, models.JobStateActive, job.ID)
+	}
+
+	sql = `
+		UPDATE jobs SET
+			metadata = jsonb_set(metadata, '{cursor}', to_jsonb($1::text)),
+			state = $2
+		WHERE id = $3
+	`
+
+	return Execute(ctx, d, sql, results.Next, models.JobStateActive, job.ID)
+}
+
+// TouchJob updates the job's last_run value.
+func (d *Database) TouchJob(ctx context.Context, jobID int64) error {
+	if err := Execute(ctx, d, "UPDATE jobs SET last_run = NOW() WHERE id = $1", jobID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// urlStringPtr returns a pointer to a string represented by a non-empty URLField.
+func urlStringPtr(u *instaproxy.URLField) *string {
+	if u == nil {
+		return nil
+	}
+
+	s := u.String()
+
+	if s == "" {
+		return nil
+	}
+
+	return &s
+}

--- a/go-instaman/service/worker.go
+++ b/go-instaman/service/worker.go
@@ -1,0 +1,210 @@
+/*
+ * Instaman - Simple Instagram account manager.
+ *
+ * Copyright (C) 2024 Luca Contini
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"time"
+
+	"github.com/luca-arch/instaman/database"
+	"github.com/luca-arch/instaman/database/models"
+	"github.com/luca-arch/instaman/instaproxy"
+)
+
+var (
+	ErrInstaproxy      = errors.New("instaproxy failure")
+	ErrInvalidMetadata = errors.New("could not parse metadata")
+	ErrNoRetry         = errors.New("instaproxy fatal")
+)
+
+const (
+	attempts             = 4 // How many pages of followers/following to consecutively fetch before pausing the job.
+	pauseBetweenAttempts = 5 // How many seconds to sleep between each fetch.
+)
+
+type dbworker interface {
+	InsertJobEvent(ctx context.Context, jobID int64, event string) error
+	NextJob(context.Context, string) (*models.Job, error)
+	ScheduleJob(context.Context, int64, time.Duration) error
+	StoreCopyJobResults(context.Context, *models.CopyJob, *instaproxy.Connections) error
+	TouchJob(context.Context, int64) error
+	UpdateJob(context.Context, database.UpdateJobParams) error
+}
+
+// Worker is the service that abstracts scheduled jobs operations from the database layer.
+type Worker struct {
+	db        dbworker
+	instagram igclient
+	logger    *slog.Logger
+}
+
+// NewWorkerService sets up and returns a new Worker Service.
+func NewWorkerService(db dbworker, logger *slog.Logger, instagramClient igclient) *Worker {
+	return &Worker{
+		db:        db,
+		instagram: instagramClient,
+		logger:    logger,
+	}
+}
+
+func (w *Worker) StartCopying(ctx context.Context) {
+	// Start first loop immediately.
+	delay := time.Millisecond
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("shutting down worker...")
+
+			return
+		case <-time.After(delay):
+			job, err := w.NextCopyJob(ctx)
+
+			// Wait one minute between each iteration.
+			delay = time.Minute
+
+			switch {
+			case err != nil:
+				w.logger.Error("could not fetch job", "error", err)
+			case job == nil:
+				continue
+			case w.db.TouchJob(ctx, job.ID) != nil:
+				w.logger.Error("could not update job timestamp", "job.id", job.ID, "job.label", job.Label)
+			default:
+				w.logger.Info("starting job", "job.id", job.ID, "job.label", job.Label, "job.type", job.Type)
+
+				if err := w.RunCopyJob(ctx, job); err != nil {
+					w.logger.Error("could not execute job", "error", err, "job.id", job.ID, "job.label", job.Label)
+
+					if err := w.db.InsertJobEvent(ctx, job.ID, err.Error()); err != nil {
+						w.logger.Error("could not log job event", "error", err)
+					}
+				}
+
+				//nolint:durationcheck // Pause for 10~15 minutes not to flood the api.
+				sleep := time.Minute * randDuration(10, 15) //nolint:mnd
+				time.Sleep(sleep)
+			}
+		}
+	}
+}
+
+// NextCopyJob returns the next scheduled CopyJob that is ready for execution.
+func (w *Worker) NextCopyJob(ctx context.Context) (*models.CopyJob, error) {
+	j, err := w.db.NextJob(ctx, models.JobTypeCopyFollowers)
+
+	switch {
+	case err != nil:
+		return nil, errors.Join(ErrDBFailure, err)
+	case j == nil:
+		j, err = w.db.NextJob(ctx, models.JobTypeCopyFollowing)
+	}
+
+	switch {
+	case err != nil:
+		return nil, errors.Join(ErrDBFailure, err)
+	case j == nil:
+		return nil, nil //nolint:nilnil // It means not found.
+	}
+
+	cj, err := models.NewCopyJob(j)
+	if err != nil {
+		return nil, errors.Join(ErrDBFailure, err)
+	}
+
+	return cj, nil
+}
+
+// RunCopyJob executes a CopyJob.
+func (w *Worker) RunCopyJob(ctx context.Context, cj *models.CopyJob) error {
+	if err := w.db.InsertJobEvent(ctx, cj.ID, "job picked up for execution"); err != nil {
+		w.logger.Error("could not log job event", "error", err)
+	}
+
+	cursor, done := cj.Metadata.Cursor, false
+
+Loop:
+	for a := range attempts {
+		res, err := w.instagram.GetFollowers(ctx, cj.Metadata.UserID, cursor)
+		if err != nil {
+			return errors.Join(
+				w.db.UpdateJob(ctx, database.UpdateJobParams{ //nolint:exhaustruct
+					ID:    cj.ID,
+					State: models.JobStateError,
+				}),
+				w.db.InsertJobEvent(ctx, cj.ID, err.Error()),
+				err,
+				ErrNoRetry,
+			)
+		}
+
+		cursor = res.Next
+
+		if err := w.db.StoreCopyJobResults(ctx, cj, res); err != nil {
+			return errors.Join(ErrDBFailure, err)
+		}
+
+		if err := w.db.InsertJobEvent(ctx, cj.ID, fmt.Sprintf("Copied %d users. Next cursor: %v", len(res.Users), cursor)); err != nil {
+			w.logger.Error("could not log job event", "error", err)
+		}
+
+		switch {
+		case cursor == nil, *cursor == "":
+			done = true
+
+			break Loop
+		case a != attempts:
+			time.Sleep(time.Duration(pauseBetweenAttempts) * time.Second)
+		}
+	}
+
+	//nolint:durationcheck // Pause for 20~30 minutes not to flood the api.
+	freq := time.Minute * randDuration(20, 30) //nolint:mnd
+
+	if done {
+		if err := w.db.InsertJobEvent(ctx, cj.ID, "Sync completed"); err != nil {
+			w.logger.Error("could not log job event", "error", err)
+		}
+
+		switch cj.Metadata.Frequency {
+		case models.JobFrequencyDaily:
+			freq = time.Hour * 24 //nolint:mnd
+		case models.JobFrequencyWeekly:
+			freq = time.Hour * 24 * 7 //nolint:mnd
+		}
+	}
+
+	if err := w.db.ScheduleJob(ctx, cj.ID, freq); err != nil {
+		return errors.Join(ErrDBFailure, err)
+	}
+
+	return nil
+}
+
+// randDuration returns a random duration in between two values.
+func randDuration(from, to int) time.Duration {
+	d := from + rand.IntN(to-from) //nolint:gosec
+
+	return time.Duration(d)
+}


### PR DESCRIPTION
# Description

Have drafted up a `worker` command that polls the database and runs jobs of the type CopyJob.
This is far from perfect but it sort of works, the Instagram API is still likely to "challenge" the access after a couple of runs, so `instaproxy` logs
> init_client: Instagram session is invalid: challenge_required

and a manual approval is required on the IG mobile app.

The database package will soon need a minor refactor to allow unit tests... But this is good for now!

# Changeset

* ✨ added Worker application files
* ✅ added cmd/worker tests (very trivial)
* 🧱 updated Dockerfile and deployment for go-instaman worker